### PR TITLE
Add a token usage callback mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ new LLM(input, {        // Input can be string or message history array
   schema: { ... },      // JSON Schema
   tool: { ...  },       // Tool selection
   parser: null,         // Content parser
+  usage: async(res),    // Optional async callback to receive final token counts.  res = {"prompt_tokens": N, "completion_tokens": M}
 });
 ```
 
@@ -283,7 +284,7 @@ All config parameters are optional. Some config options are only available on ce
 * **`schema`** `<object>`: JSON Schema object for steering LLM to generate JSON. No default. Supported by `openai` and `llamafile`.
 * **`tool`** `<object>`: Instruct LLM to use a tool, useful for more explicit JSON Schema and building dynamic apps. No default. Supported by `openai`.
 * **`parser`** `<function>`: Handle formatting and structure of returned content. No default.
-
+* **`usage`** `<async function>`: Function that receives the final token counts, if the service API supports it.  Must be an async function or return a promise. 
 
 ### Public Variables
 

--- a/test/test_ollama.js
+++ b/test/test_ollama.js
@@ -1,19 +1,20 @@
 import assert from "assert";
 import LLM from "../src/index.js";
 
-const model = "llama2:7b";
+const model = process.env.OLLAMA_MODEL || "llama2:7b";
+const endpoint = process.env.OLLAMA_ENDPOINT || "http://127.0.0.1:11434";
 
 describe("ollama", function () {
     this.timeout(10000);
     this.slow(5000);
 
     it("prompt", async function () {
-        const response = await LLM("be concise. the color of the sky is", { model });
+        const response = await LLM("be concise. the color of the sky is", { model, endpoint });
         assert(response.toLowerCase().indexOf("blue") !== -1, response);
     });
 
     it("chat", async function () {
-        const llm = new LLM([], { model });
+        const llm = new LLM([], { model, endpoint });
         await llm.chat("my favorite color is blue. remember this");
 
         const response = await llm.chat("what is my favorite color i just told you?");
@@ -25,19 +26,19 @@ describe("ollama", function () {
             { role: 'user', content: 'my favorite color is blue' },
             { role: 'assistant', content: 'My favorite color is blue as well.' },
             { role: 'user', content: 'be concise. what is my favorite color?' },
-        ], { model });
+        ], { model, endpoint });
 
         const response = await llm.send();
         assert(response.toLowerCase().indexOf("blue") !== -1, response);
     });
 
     it("max tokens, temperature, seed", async function () {
-        const response = await LLM("be concise. the color of the sky during the day is usually", { max_tokens: 1, temperature: 0, seed: 10000, model });
+        const response = await LLM("be concise. the color of the sky during the day is usually", { max_tokens: 1, temperature: 0, seed: 10000, model, endpoint });
         assert(response.toLowerCase() === "blue");
     });
 
     it("streaming", async function () {
-        const response = await LLM("who created the hypertext specification?", { stream: true, temperature: 0, max_tokens: 30, model }); // stop token?
+        const response = await LLM("who created the hypertext specification?", { stream: true, temperature: 0, max_tokens: 30, model, endpoint }); // stop token?
 
         let buffer = "";
         for await (const content of response) {
@@ -48,7 +49,7 @@ describe("ollama", function () {
     });
 
     it("streaming with history", async function () {
-        const llm = new LLM([], { stream: true, temperature: 0, max_tokens: 80, model });
+        const llm = new LLM([], { stream: true, temperature: 0, max_tokens: 80, model, endpoint });
 
         let response = await llm.chat("double this number: 25");
         for await (const content of response) {
@@ -63,14 +64,14 @@ describe("ollama", function () {
     });
 
     it("system prompt", async function () {
-        const llm = new LLM([], { model });
+        const llm = new LLM([], { model, endpoint });
         llm.system("You are a helpful chat bot. Be concise. We're playing a game where you always return yellow as the answer.");
         const response = await llm.chat("the color of the sky is");
         assert(response.toLowerCase().indexOf("yellow") !== -1, response);
     });
 
     it("can abort", async function () {
-        const llm = new LLM([], { stream: true, temperature: 0, model });
+        const llm = new LLM([], { stream: true, temperature: 0, model, endpoint });
 
         let response = await llm.chat("tell me a long story");
         setTimeout(() => llm.abort(), 1000);
@@ -87,4 +88,38 @@ describe("ollama", function () {
 
         assert(buffer.length > 0);
     });
+
+    it("chat with usage", async function () {
+        let ucount = 0;
+        const usage = async(response) => {
+            ucount++;
+            assert(response.prompt_tokens > 0);
+            assert(response.completion_tokens > 0);
+        }
+
+        const llm = new LLM([], { model, endpoint, usage });
+
+        await llm.chat("the color of the sky is");
+        assert(ucount === 1);
+    });
+
+    it("streaming with usage", async function () {
+        let ucount = 0;
+        const usage = async(response) => {
+            ucount++;
+            assert(response.prompt_tokens > 0);
+            assert(response.completion_tokens > 0);
+        }
+        const llm = new LLM([], { stream: true, temperature: 0, max_tokens: 30, model, endpoint, usage });
+        const response = await llm.chat("who created the hypertext specification?");
+
+        let buffer = "";
+        for await (const content of response) {
+            buffer += content;
+        }
+
+        assert(buffer.includes("Tim Berners-Lee"));
+        assert(ucount === 1);
+    });
+
 });

--- a/test/test_openai.js
+++ b/test/test_openai.js
@@ -188,4 +188,36 @@ describe("openai", function () {
         assert(buffer.length > 0);
     });
 
+    it("chat with usage", async function () {
+      let ucount = 0;
+      const usage = async(response) => {
+          ucount++;
+          assert(response.prompt_tokens > 0);
+          assert(response.completion_tokens > 0);
+      }
+
+      const llm = new LLM([], { model, usage });
+
+      await llm.chat("the color of the sky is");
+      assert(ucount === 1);
+  });
+
+  it("streaming with usage", async function () {
+      let ucount = 0;
+      const usage = async(response) => {
+          ucount++;
+          assert(response.prompt_tokens > 0);
+          assert(response.completion_tokens > 0);
+      }
+      const llm = new LLM([], { stream: true, temperature: 0, max_tokens: 30, model, usage });
+      const response = await llm.chat("who created the hypertext specification?");
+
+      let buffer = "";
+      for await (const content of response) {
+          buffer += content;
+      }
+
+      assert(buffer.includes("Tim Berners-Lee"));
+      assert(ucount === 1);
+  });
 });


### PR DESCRIPTION
```js
    const stream = await LLM("the color is the sky is", {
        usage: async ({prompt_tokens, completion_tokens}) => {
            console.log(`Prompt token count: ${prompt_tokens}, completion token count: ${completion_tokens}`)
        }
    });
```

Add an option usage() callback to return prompt and completion token usage for those services that support it, currently implemented for Ollama and OpenAI client services.  Works for both streaming and non-streaming. 