### PR TITLE
Move esbuild to dev deps, run npm install to update packatge-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@themaximalist/llm.js",
-    "version": "0.6.5",
+    "version": "0.6.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@themaximalist/llm.js",
-            "version": "0.6.5",
+            "version": "0.6.6",
             "license": "MIT",
             "dependencies": {
                 "commander": "^11.1.0",
@@ -14,7 +14,6 @@
                 "debug": "^4.3.4",
                 "diff": "^5.2.0",
                 "dotenv-extended": "^2.9.0",
-                "esbuild": "^0.20.2",
                 "eventemitter3": "^5.0.1",
                 "ollama": "^0.4.9",
                 "openai": "^4.35.8",
@@ -25,6 +24,7 @@
                 "llm": "src/cli.js"
             },
             "devDependencies": {
+                "esbuild": "^0.20.2",
                 "mocha": "^10.2.0"
             }
         },
@@ -35,6 +35,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "aix"
@@ -50,6 +51,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -65,6 +67,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -80,6 +83,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -95,6 +99,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -110,6 +115,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -125,6 +131,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -140,6 +147,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "freebsd"
@@ -155,6 +163,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -170,6 +179,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -185,6 +195,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -200,6 +211,7 @@
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -215,6 +227,7 @@
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -230,6 +243,7 @@
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -245,6 +259,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -260,6 +275,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -275,6 +291,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -290,6 +307,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "netbsd"
@@ -305,6 +323,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "openbsd"
@@ -320,6 +339,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "sunos"
@@ -335,6 +355,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -350,6 +371,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -365,6 +387,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -756,6 +779,7 @@
             "version": "0.20.2",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
             "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "dev": true,
             "hasInstallScript": true,
             "bin": {
                 "esbuild": "bin/esbuild"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "debug": "^4.3.4",
         "diff": "^5.2.0",
         "dotenv-extended": "^2.9.0",
-        "esbuild": "^0.20.2",
         "eventemitter3": "^5.0.1",
         "openai": "^4.35.8",
         "ollama": "^0.4.9",
@@ -35,6 +34,7 @@
         "prompt-sync-history": "^1.0.1"
     },
     "devDependencies": {
-        "mocha": "^10.2.0"
+        "mocha": "^10.2.0",
+        "esbuild": "^0.20.2"
     }
 }


### PR DESCRIPTION
https://github.com/themaximalist/llm.js/issues/10

This changed the installed version of `llm.js` in `package-lock.json` from `0.6.5` to `0.6.6`. Not sure about what consequences that might have.